### PR TITLE
Fix/interaction style names

### DIFF
--- a/babel-plugin/__test__/__snapshots__/index.test.jsx.snap
+++ b/babel-plugin/__test__/__snapshots__/index.test.jsx.snap
@@ -93,7 +93,7 @@ const StyledPressable = _rnStyledVariants__react.forwardRef((props, ref) => {
     currentBreakpoint,
     getClosestResponsiveValue
   }) => ({
-    baseStyle_focus: {
+    baseStyle_focused: {
       backgroundColor: theme[\\"colors\\"][\\"pressed\\"]
     },
     baseStyle: {
@@ -103,7 +103,7 @@ const StyledPressable = _rnStyledVariants__react.forwardRef((props, ref) => {
   }), [\\"theme\\"]);
 
   const style = _rnStyledVariants__react.useMemo(() => {
-    const newStyle = [styleSheet.baseStyle, isFocused ? styleSheet.baseStyle_focus : undefined, propStyle].filter(Boolean);
+    const newStyle = [styleSheet.baseStyle, isFocused ? styleSheet.baseStyle_focused : undefined, propStyle].filter(Boolean);
     return newStyle;
   }, [styleSheet, isFocused, propStyle]);
 
@@ -125,14 +125,14 @@ const StyledPressable = _rnStyledVariants__react.forwardRef((props, ref) => {
     currentBreakpoint,
     getClosestResponsiveValue
   }) => ({
-    baseStyle_focus: {
+    baseStyle_focused: {
       backgroundColor: theme[\\"colors\\"][\\"pressed\\"]
     },
     baseStyle: {
       padding: theme[\\"space\\"][\\"3\\"],
       backgroundColor: theme[\\"colors\\"][\\"primary\\"]
     },
-    checked_true_focus: {
+    checked_true_focused: {
       backgroundColor: theme[\\"colors\\"][\\"pressed_checked\\"]
     },
     checked_true: {}
@@ -141,7 +141,7 @@ const StyledPressable = _rnStyledVariants__react.forwardRef((props, ref) => {
   const style = _rnStyledVariants__react.useMemo(() => {
     const newStyle = [styleSheet.baseStyle, 
             styleSheet[\`checked_\${checked}\`]
-        , isFocused ? styleSheet.baseStyle_focus : undefined, isFocused ? styleSheet[\`checked_\${checked}_focus\`] : undefined, propStyle].filter(Boolean);
+        , isFocused ? styleSheet.baseStyle_focused : undefined, isFocused ? styleSheet[\`checked_\${checked}_focused\`] : undefined, propStyle].filter(Boolean);
     return newStyle;
   }, [styleSheet, isFocused, checked, propStyle]);
 
@@ -163,7 +163,7 @@ const StyledPressable = _rnStyledVariants__react.forwardRef((props, ref) => {
     currentBreakpoint,
     getClosestResponsiveValue
   }) => ({
-    baseStyle_hover: {
+    baseStyle_hovered: {
       backgroundColor: theme[\\"colors\\"][\\"hover\\"]
     },
     baseStyle: {
@@ -178,7 +178,7 @@ const StyledPressable = _rnStyledVariants__react.forwardRef((props, ref) => {
   const style = _rnStyledVariants__react.useMemo(() => {
     const newStyle = [styleSheet.baseStyle, 
             styleSheet[\`color_\${color}\`]
-        , isHovered ? styleSheet.baseStyle_hover : undefined, propStyle].filter(Boolean);
+        , isHovered ? styleSheet.baseStyle_hovered : undefined, propStyle].filter(Boolean);
     return newStyle;
   }, [styleSheet, isHovered, color, propStyle]);
 

--- a/babel-plugin/__test__/index.test.jsx
+++ b/babel-plugin/__test__/index.test.jsx
@@ -79,7 +79,7 @@ describe('test createVariant transform plugin', () => {
     const StyledPressable = createVariant(Pressable, {
       padding: "$space.3",
       backgroundColor: "$colors.blue.800",
-      _hover: {
+      _hovered: {
         backgroundColor: "$colors.hover",
       },
       variants: {
@@ -137,7 +137,7 @@ describe('test createVariant transform plugin', () => {
     const StyledPressable = createVariant(Pressable, {
       padding: "$space.3",
       backgroundColor: "$colors.primary",
-      _focus: {
+      _focused: {
         backgroundColor: "$colors.pressed",
       },
     });
@@ -151,13 +151,13 @@ describe('test createVariant transform plugin', () => {
     const StyledPressable = createVariant(Pressable, {
       padding: "$space.3",
       backgroundColor: "$colors.primary",
-      _focus: {
+      _focused: {
         backgroundColor: "$colors.pressed",
       },
       variants: {
         checked: {
           true: {
-            _focus: {
+            _focused: {
               backgroundColor: "$colors.pressed_checked",
             },
           }

--- a/babel-plugin/package.json
+++ b/babel-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-styled-variants",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "main": "index.js",
   "author": "nishan",
   "license": "MIT",

--- a/example/src/AnimeApp/App.tsx
+++ b/example/src/AnimeApp/App.tsx
@@ -68,13 +68,13 @@ const Screen = () => {
         }}
       >
         <Button onPress={changeImage} accessibilityRole="button">
-          {({ pressed }) => {
+          {({ pressed, hovered, focused }: any) => {
             return (
               <StyledText
                 uppercase
                 bold
                 sx={
-                  pressed
+                  pressed || hovered || focused
                     ? {
                         color: Platform.select({
                           web: '$colors.white',
@@ -147,11 +147,14 @@ const Button = createVariant(Pressable, {
   borderColor: '$colors.red.2',
   width: Platform.select({ web: 250, default: '80%' as any }),
   alignItems: 'center',
-  _hover: {
+  _hovered: {
     backgroundColor: '$colors.red.0',
   },
   _pressed: {
     backgroundColor: '$colors.red.1',
+  },
+  _focused: {
+    backgroundColor: '$colors.red.2',
   },
 });
 

--- a/example/src/BenchmarkApp/Benchmark.tsx
+++ b/example/src/BenchmarkApp/Benchmark.tsx
@@ -65,7 +65,7 @@ const VariantButton = createVariant(Pressable, {
   _pressed: {
     backgroundColor: '$colors.pressed',
   },
-  _hover: {
+  _hovered: {
     backgroundColor: '$colors.button_hover',
   },
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-styled-variants",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "Create styled variants that are transpiled to StyleSheet during build time",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,9 +58,9 @@ export type RNStyles<Theme, BreakPoints> = ExtendStyleWithBreakpointValues<
 >;
 
 interface AllStyles<Theme, Breakpoints> extends RNStyles<Theme, Breakpoints> {
-  _hover?: RNStyles<Theme, Breakpoints>;
+  _hovered?: RNStyles<Theme, Breakpoints>;
   _pressed?: RNStyles<Theme, Breakpoints>;
-  _focus?: RNStyles<Theme, Breakpoints>;
+  _focused?: RNStyles<Theme, Breakpoints>;
 }
 
 export interface IStyles<Theme, Breakpoints, DefinedStyles extends IStyle>


### PR DESCRIPTION
This PR makes interaction style names consistent with react-native-web's convention.

- Pressed, focused and hovered https://necolas.github.io/react-native-web/docs/pressable/#interactionstate
- Updates testcases and typings for the same.